### PR TITLE
Update Transform icons with Blender-like ones

### DIFF
--- a/hicolor/scalable/friction-tools/boxTransform.svg
+++ b/hicolor/scalable/friction-tools/boxTransform.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 6.6145832 6.6145835"
    version="1.1"
    id="svg1468"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
    sodipodi:docname="boxTransform.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -18,17 +18,17 @@
      id="defs1462" />
   <sodipodi:namedview
      id="base"
-     pagecolor="#ffffff"
+     pagecolor="#000000"
      bordercolor="#666666"
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.839192"
-     inkscape:cx="9.9121218"
-     inkscape:cy="14.584077"
+     inkscape:zoom="24.045009"
+     inkscape:cx="11.249736"
+     inkscape:cy="11.977537"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
-     showgrid="false"
+     showgrid="true"
      units="px"
      inkscape:window-width="1920"
      inkscape:window-height="1013"
@@ -36,7 +36,26 @@
      inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:document-rotation="0"
-     inkscape:pagecheckerboard="1" />
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.26458333"
+       spacingy="0.26458331"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
   <metadata
      id="metadata1465">
     <rdf:RDF>
@@ -45,7 +64,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -54,11 +72,15 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-290.3854)">
-    <path
-       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.337001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.4;stroke-opacity:1"
-       d="m 1.286798,291.6722 1.3383045,3.9257 0.7128345,-1.22027 0.9275672,1.33555 1.0622804,-1.06227 -1.3341693,-0.9271 1.2188808,-0.7133 z"
-       id="path1456"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
+    <g
+       fill="#ffffff"
+       id="g1175"
+       transform="matrix(0.00379249,0,0,0.00379249,1.0219411,291.32977)"
+       style="opacity:1">
+      <path
+         d="m 470.49125,433 c -0.3497,0.006 -0.58488,0.36077 -0.45507,0.68555 l 4,10.00195 c 0.1779,0.45034 0.82806,0.4102 0.94922,-0.0586 l 1.17578,-4.46875 4.46679,-1.17578 c 0.46499,-0.12321 0.50486,-0.76769 0.0586,-0.94727 l -10,-4.00195 c -0.0621,-0.0247 -0.12852,-0.0366 -0.19532,-0.0351 z"
+         transform="matrix(100,0,0,100,-46899.999,-43200.19)"
+         id="path1173" />
+    </g>
   </g>
 </svg>

--- a/hicolor/scalable/friction-tools/pointTransform.svg
+++ b/hicolor/scalable/friction-tools/pointTransform.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 6.6145832 6.6145835"
    version="1.1"
    id="svg1468"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
    sodipodi:docname="pointTransform.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -23,9 +23,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.581481"
-     inkscape:cx="12.865367"
-     inkscape:cy="11.397507"
+     inkscape:zoom="24.045009"
+     inkscape:cx="11.249736"
+     inkscape:cy="11.977537"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -72,15 +72,9 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-290.3854)">
-    <g
-       fill="#ffffff"
-       id="g1175"
-       transform="matrix(0.00379249,0,0,0.00379249,1.0219411,291.32977)"
-       style="opacity:1">
-      <path
-         d="m 470.49125,433 c -0.3497,0.006 -0.58488,0.36077 -0.45507,0.68555 l 4,10.00195 c 0.1779,0.45034 0.82806,0.4102 0.94922,-0.0586 l 1.17578,-4.46875 4.46679,-1.17578 c 0.46499,-0.12321 0.50486,-0.76769 0.0586,-0.94727 l -10,-4.00195 c -0.0621,-0.0247 -0.12852,-0.0366 -0.19532,-0.0351 z"
-         transform="matrix(100,0,0,100,-46899.999,-43200.19)"
-         id="path1173" />
-    </g>
+    <path
+       id="path1"
+       style="fill:#ffffff;stroke:none;stroke-width:79.3749;stroke-opacity:1"
+       d="M 1.5875 291.70832 C 1.4548766 291.71032 1.3656704 291.84508 1.4149007 291.96825 L 2.9321208 295.7613 C 2.9995888 295.93209 3.2458389 295.91685 3.2917887 295.73908 L 3.7377563 294.04461 L 5.4317098 293.59864 C 5.6080568 293.55194 5.6231743 293.3076 5.4539307 293.23949 L 1.6613973 291.72175 C 1.6378463 291.71275 1.612834 291.70772 1.5875 291.70832 z M 1.9626709 292.26952 L 4.7242594 293.37436 L 3.4132284 293.71956 L 3.0680298 295.03266 L 1.9626709 292.26952 z " />
   </g>
 </svg>


### PR DESCRIPTION
As talked in https://github.com/friction2d/friction-icon-theme/issues/14

<img width="65" alt="pointers" src="https://github.com/user-attachments/assets/cc6c4a3f-5d25-4863-82aa-702112d051cb">
