### PR TITLE
Icons for node removal (normal and approx.)

### DIFF
--- a/hicolor/scalable/friction-nodes/nodeRemove.svg
+++ b/hicolor/scalable/friction-nodes/nodeRemove.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="25"
+   height="25"
+   viewBox="0 0 6.6145832 6.6145835"
+   version="1.1"
+   id="svg1468"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   sodipodi:docname="nodeRemove.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1462" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="24.045009"
+     inkscape:cx="11.561651"
+     inkscape:cy="12.518191"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata1465">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.3854)">
+    <path
+       id="path841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:Chilanka;-inkscape-font-specification:Chilanka;letter-spacing:0px;word-spacing:0px;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:0.19299;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3.4147188,293.38946 c -0.067742,0 -0.1254475,0.0238 -0.1731176,0.0715 -0.04767,0.0476 -0.071505,0.10538 -0.071505,0.17312 0,0.0677 0.023835,0.12545 0.071505,0.17313 0.04767,0.0477 0.1053759,0.0715 0.1731176,0.0715 h 1.65967 c 0.067742,0 0.1254475,-0.0238 0.1731176,-0.0715 0.04767,-0.0477 0.071505,-0.10539 0.071505,-0.17313 0,-0.0677 -0.023835,-0.12544 -0.071505,-0.17312 -0.04767,-0.0477 -0.1053761,-0.0715 -0.1731176,-0.0715 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scscsssscss" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path816"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 1.9063436,291.31661 v 4.75665 l 0.2656168,-0.005 v -4.75148 z" />
+    <path
+       id="path1"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 2.0505208,293.10797 c -0.3227446,1.2e-4 -0.5843544,0.26172 -0.5844604,0.58446 1.06e-4,0.32274 0.2617158,0.58436 0.5844604,0.58446 0.3227445,-10e-5 0.5843545,-0.26172 0.5844605,-0.58446 -1.06e-4,-0.32274 -0.261716,-0.58434 -0.5844605,-0.58446 z" />
+  </g>
+</svg>

--- a/hicolor/scalable/friction-nodes/nodeRemoveApprox.svg
+++ b/hicolor/scalable/friction-nodes/nodeRemoveApprox.svg
@@ -23,9 +23,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.839192"
-     inkscape:cx="11.932427"
-     inkscape:cy="13.51079"
+     inkscape:zoom="17.581503"
+     inkscape:cx="8.3610599"
+     inkscape:cy="13.536954"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -65,24 +65,29 @@
        id="path1"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 2.0505208,293.10797 c -0.3227446,1.2e-4 -0.5843544,0.26172 -0.5844604,0.58446 1.06e-4,0.32274 0.2617158,0.58436 0.5844604,0.58446 0.3227445,-10e-5 0.5843545,-0.26172 0.5844605,-0.58446 -1.06e-4,-0.32274 -0.261716,-0.58434 -0.5844605,-0.58446 z" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       d="m 2.4293325,292.21334 c -0.2586471,0.36493 -0.3788117,0.89463 -0.3788116,1.47909"
+       id="path4"
+       sodipodi:nodetypes="cc" />
     <ellipse
        style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
-       id="ellipse2"
-       cx="3.2086689"
+       id="ellipse1"
+       cx="2.7564604"
        cy="291.90112"
        rx="0.45220852"
        ry="0.45220849" />
     <ellipse
        style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
-       id="ellipse4"
-       cx="3.2086689"
+       id="ellipse5"
+       cx="2.7564604"
        cy="295.48877"
        rx="0.45220852"
        ry="0.45220849" />
     <path
        style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
-       d="m 2.8467044,292.17218 c -1.0658926,1.01731 -1.0615703,2.027 0.01292,3.02908"
-       id="path4"
+       d="M 2.4293325,295.17152 C 2.1706854,294.80659 2.0505208,294.27689 2.0505209,293.69243"
+       id="path5"
        sodipodi:nodetypes="cc" />
   </g>
 </svg>

--- a/hicolor/scalable/friction-nodes/nodeRemoveApprox.svg
+++ b/hicolor/scalable/friction-nodes/nodeRemoveApprox.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="25"
+   height="25"
+   viewBox="0 0 6.6145832 6.6145835"
+   version="1.1"
+   id="svg1468"
+   inkscape:version="1.4.2 (ebf0e940, 2025-05-08)"
+   sodipodi:docname="nodeRemoveApprox.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1462" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="11.932427"
+     inkscape:cy="13.51079"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata1465">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.3854)">
+    <path
+       id="path841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:Chilanka;-inkscape-font-specification:Chilanka;letter-spacing:0px;word-spacing:0px;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:0.19299;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3.4147188,293.38946 c -0.067742,0 -0.1254475,0.0238 -0.1731176,0.0715 -0.04767,0.0476 -0.071505,0.10538 -0.071505,0.17312 0,0.0677 0.023835,0.12545 0.071505,0.17313 0.04767,0.0477 0.1053759,0.0715 0.1731176,0.0715 h 1.65967 c 0.067742,0 0.1254475,-0.0238 0.1731176,-0.0715 0.04767,-0.0477 0.071505,-0.10539 0.071505,-0.17313 0,-0.0677 -0.023835,-0.12544 -0.071505,-0.17312 -0.04767,-0.0477 -0.1053761,-0.0715 -0.1731176,-0.0715 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scscsssscss" />
+    <path
+       id="path1"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 2.0505208,293.10797 c -0.3227446,1.2e-4 -0.5843544,0.26172 -0.5844604,0.58446 1.06e-4,0.32274 0.2617158,0.58436 0.5844604,0.58446 0.3227445,-10e-5 0.5843545,-0.26172 0.5844605,-0.58446 -1.06e-4,-0.32274 -0.261716,-0.58434 -0.5844605,-0.58446 z" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="ellipse2"
+       cx="3.2086689"
+       cy="291.90112"
+       rx="0.45220852"
+       ry="0.45220849" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="ellipse4"
+       cx="3.2086689"
+       cy="295.48877"
+       rx="0.45220852"
+       ry="0.45220849" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#f9f9f9;stroke-width:0.264583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       d="m 2.8467044,292.17218 c -1.0658926,1.01731 -1.0615703,2.027 0.01292,3.02908"
+       id="path4"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>


### PR DESCRIPTION
Related with a new PR https://github.com/friction2d/friction/pull/605 for making easier to remove nodes from the toolbox:

<img width="166" height="80" alt="remove_nodes" src="https://github.com/user-attachments/assets/d12cec21-a391-4cef-ac07-832ce2a51e93" />

